### PR TITLE
.NET 9 へターゲットフレームワークを更新

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,7 @@ permissions:
   contents: read
 
 env:
-  DOTNET_VERSION: "8.0.x"
+  DOTNET_VERSION: "9.0.x"
 
 jobs:
   build:

--- a/src/FileSifter/FileSifter.csproj
+++ b/src/FileSifter/FileSifter.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net8.0-windows</TargetFramework>
+    <TargetFramework>net9.0-windows</TargetFramework>
     <Nullable>enable</Nullable>
     <UseWPF>true</UseWPF>
     <ImplicitUsings>enable</ImplicitUsings>


### PR DESCRIPTION
概要: src/FileSifter/FileSifter.csproj のターゲットフレームワークを .NET 9 (net9.0-windows) に更新します。SDK/ランタイムのアップグレードに伴う互換性確認を目的としたメンテナンス作業です。

変更点
•	FileSifter/FileSifter.csproj の TargetFramework を net9.0-windows に更新
•	（必要に応じて）global.json を追加/更新して開発用の SDK バージョンを固定（存在する場合）
•	依存パッケージの互換性確認（破壊的変更は未検出/要レビュー）